### PR TITLE
Callback of failure on iOS devices causes "Invalid callback id received ...

### DIFF
--- a/src/ios/AdColonyPlugin.m
+++ b/src/ios/AdColonyPlugin.m
@@ -67,8 +67,8 @@
         [self sendPluginErrorToCallbackId:command.callbackId message:@"Ad currently playing"];
     } else {
         NSString *zoneId = [command.arguments objectAtIndex:0];
-        [AdColony playVideoAdForZone:zoneId withDelegate:self];
         self.videoAdCallbackId = command.callbackId;
+        [AdColony playVideoAdForZone:zoneId withDelegate:self];
     }
 }
 
@@ -83,8 +83,8 @@
     } else {
         NSString *zoneId = [command.arguments objectAtIndex:0];
         // TODO: Make pre/post popups optional
-        [AdColony playVideoAdForZone:zoneId withDelegate:self withV4VCPrePopup:YES andV4VCPostPopup:YES];
         self.videoAdCallbackId = command.callbackId;
+        [AdColony playVideoAdForZone:zoneId withDelegate:self withV4VCPrePopup:YES andV4VCPostPopup:YES];
     }
 }
 
@@ -263,7 +263,8 @@
 - (void)onAdColonyAdStartedInZone:(NSString *)zoneId
 {
     [self sendPluginOKToCallbackId:self.videoAdCallbackId];
-    self.videoAdCallbackId = nil;
+    // Commenting out the following line as this will prevent any future calls for the current video from succeeding
+    // self.videoAdCallbackId = nil;
 }
 
 /**


### PR DESCRIPTION
...by sendPluginResult" calls to occur. This fixes this by changing the order in which the self.callbackId is set around the AdColony calls, and removing a line which set the value of the self.callbackId to nil while an active advert was playing.

Testing locally when AdColony isn't providing ads, I was noticing that the "Invalid callback id received by sendPluginResult" message was appearing in the logs, and more importantly, my failure callbacks weren't being called despite the ad definitely failing. Digging around a little, it appears that in some situations, the callback from the AdColony code for saying that an error has happened, via the delegate, is occurring as part of the show video ad call, and not asynchronously. This causes a failure, because our delegate hasn't had self.callbackId set yet, as it is due to occur after the AdColony call.

This PR changes this order, so that the delegate always has the correct callbackId.

I also noticed an interesting code path which is when AdColony notify us that the ad is playing in the zone... we set the value of the self.callbackId to nil, yet we know that at some point down the line, we are going to get an onAdColonyAdAttemptFinished command which in an error state, requires the self.callbackId.
