### PR TITLE
Upgrading to iOS SDK 2.5.1 and fix Web Audio after advert

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Compatible with:
 
 ## NOTE: ##
 
+This particular fork has support for the AdColony 2.5.1 iOS SDK. It also has support for an issue whereby if you are
+using Web Audio, and this is at a different audio sample rate to the video that is played, when the advert completes,
+the audio in the app is all broken up. We capture the audio sample rate prior to launching the advert,
+and on completion, request this sample rate once again.
+
 The repo location has changed.  Future-proof by updating your remote:
 ```
 git remote set-url origin git@github.com:affinityis/cordova-adcolony-plugin.git

--- a/src/ios/AdColony.framework/Versions/A/Headers/AdColony.h
+++ b/src/ios/AdColony.framework/Versions/A/Headers/AdColony.h
@@ -15,13 +15,13 @@
 /**
  * Enum for zone status
  */
-typedef enum {
+typedef NS_ENUM(NSUInteger, ADCOLONY_ZONE_STATUS) {
     ADCOLONY_ZONE_STATUS_NO_ZONE = 0,   /**< AdColony has not been configured with that zone ID. */
     ADCOLONY_ZONE_STATUS_OFF,           /**< The zone has been turned off on the [Control Panel](http://clients.adcolony.com). */
     ADCOLONY_ZONE_STATUS_LOADING,       /**< The zone is preparing ads for display. */
     ADCOLONY_ZONE_STATUS_ACTIVE,        /**< The zone has completed preparing ads for display. */
     ADCOLONY_ZONE_STATUS_UNKNOWN        /**< AdColony has not yet received the zone's configuration from the server. */
-} ADCOLONY_ZONE_STATUS;
+};
 
 #pragma mark -
 #pragma mark Forward declarations

--- a/src/ios/AdColony.framework/Versions/A/Headers/AdColonyAdInfo.h
+++ b/src/ios/AdColony.framework/Versions/A/Headers/AdColonyAdInfo.h
@@ -53,7 +53,7 @@ typedef enum {
 @property (nonatomic, readonly) NSString *iapProductID;
 
 /**
- * The number of items the user wishes to purchase.
+ * The number of items to be purchased.
  * @param iapQuantity An int denoting the number of items the user wishes to purchase.
  */
 @property (nonatomic, readonly) int iapQuantity;

--- a/src/ios/AdColony.framework/Versions/A/Headers/AdColonyNativeAdView.h
+++ b/src/ios/AdColony.framework/Versions/A/Headers/AdColonyNativeAdView.h
@@ -68,7 +68,7 @@
  * Use this property to access the UIButton and customize anything about it except its title text and tap action.
  * @param engagementButton The engagement button that is already embedded within this ad.
  */
-@property (nonatomic) UIButton* engagementButton;
+@property (nonatomic, readonly) UIButton* engagementButton;
 
 /**
  * Returns the recommended height for the AdColonyNativeAdView if it will be displayed at the specified width.
@@ -161,4 +161,10 @@
  * @param muted Whether the ad was muted or unmuted.
  */
 -(void)onAdColonyNativeAd:(AdColonyNativeAdView*)ad muted:(BOOL)muted;
+
+/**
+ * Notifies your app that a user has engaged with the native ad via an in-video engagement mechanism.
+ * @param ad The affected native ad view.
+ */
+-(void)onAdColonyNativeAdEngagementPressed:(AdColonyNativeAdView*)ad;
 @end

--- a/src/ios/AdColonyPlugin.h
+++ b/src/ios/AdColonyPlugin.h
@@ -46,6 +46,7 @@
 @property (nonatomic, copy) NSString *videoAdCallbackId;           /*!< The callback ID for video ads */
 @property (nonatomic, copy) NSString *nativeAdCallbackId;          /*!< The callback ID for native ads */
 @property (nonatomic) BOOL hasInitialized;
+@property (nonatomic) double previousSampleRate;
 
 // @interface AppDelegate (CDVParsePlugin)
 @end

--- a/src/ios/AdColonyPlugin.m
+++ b/src/ios/AdColonyPlugin.m
@@ -67,8 +67,8 @@
         [self sendPluginErrorToCallbackId:command.callbackId message:@"Ad currently playing"];
     } else {
         NSString *zoneId = [command.arguments objectAtIndex:0];
-        [AdColony playVideoAdForZone:zoneId withDelegate:self];
         self.videoAdCallbackId = command.callbackId;
+        [AdColony playVideoAdForZone:zoneId withDelegate:self];
     }
 }
 
@@ -83,8 +83,8 @@
     } else {
         NSString *zoneId = [command.arguments objectAtIndex:0];
         // TODO: Make pre/post popups optional
-        [AdColony playVideoAdForZone:zoneId withDelegate:self withV4VCPrePopup:YES andV4VCPostPopup:YES];
         self.videoAdCallbackId = command.callbackId;
+        [AdColony playVideoAdForZone:zoneId withDelegate:self withV4VCPrePopup:YES andV4VCPostPopup:YES];
     }
 }
 
@@ -263,7 +263,8 @@
 - (void)onAdColonyAdStartedInZone:(NSString *)zoneId
 {
     [self sendPluginOKToCallbackId:self.videoAdCallbackId];
-    self.videoAdCallbackId = nil;
+    // Commenting out the following line as this will prevent any future calls for the current video from succeeding
+    // self.videoAdCallbackId = nil;
 }
 
 /**

--- a/src/ios/AdColonyPlugin.m
+++ b/src/ios/AdColonyPlugin.m
@@ -26,6 +26,7 @@
  #import <Cordova/CDV.h>
  #import <objc/runtime.h>
  #import <objc/message.h>
+ #import <AVFoundation/AVAudioSession.h>
 
  @implementation AdColonyPlugin
 
@@ -66,6 +67,8 @@
     if ([AdColony videoAdCurrentlyRunning]) {
         [self sendPluginErrorToCallbackId:command.callbackId message:@"Ad currently playing"];
     } else {
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        self.previousSampleRate = session.sampleRate;
         NSString *zoneId = [command.arguments objectAtIndex:0];
         self.videoAdCallbackId = command.callbackId;
         [AdColony playVideoAdForZone:zoneId withDelegate:self];
@@ -81,6 +84,8 @@
     if ([AdColony videoAdCurrentlyRunning]) {
         [self sendPluginErrorToCallbackId:command.callbackId message:@"Ad currently playing"];
     } else {
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        self.previousSampleRate = session.sampleRate;
         NSString *zoneId = [command.arguments objectAtIndex:0];
         // TODO: Make pre/post popups optional
         self.videoAdCallbackId = command.callbackId;
@@ -276,6 +281,9 @@
  */
 - (void)onAdColonyAdAttemptFinished:(BOOL)shown inZone:(NSString *)zoneId
 {
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    [session setPreferredSampleRate: self.previousSampleRate error: nil];
+    
     if (shown) {
         [self fireEvent:@"adcompleted" data:@{@"zoneId": zoneId}];
     } else {


### PR DESCRIPTION
Two issues here.

One - Upgrade to latest iOS SDK - Relatively trivial
Two - When your app uses audio which is at a different sample rate to when a video is played by Ad Colony (Ad Colony adverts seem to be running at 48khz, and our own audio runs at 44.1khz), the audio in the app after the advert is all distorted. By capturing the sample rate prior to launching the video advert, and then requesting the audio rate you previously had, this fixes the broken audio.
